### PR TITLE
Added forecast table header and option to hide forecast table column header icons

### DIFF
--- a/MMM-DarkSkyForecast.css
+++ b/MMM-DarkSkyForecast.css
@@ -77,6 +77,20 @@
   margin: 15px 0;
 }
 
+/* Module Header below current conditions */
+
+.MMM-DarkSkyForecast .module-header {
+  text-transform: uppercase;
+  font-size: 15px;
+  font-family: "Roboto Condensed", Arial, Helvetica, sans-serif;
+  font-weight: 400;
+  border-bottom: 1px solid #666;
+  line-height: 15px;
+  padding-bottom: 5px;
+  padding-top: 5px;
+  margin-bottom: 10px;
+  color: #999;
+}
 
 /* ------------ Forecast ------------ */
 

--- a/MMM-DarkSkyForecast.js
+++ b/MMM-DarkSkyForecast.js
@@ -10,8 +10,8 @@ Module.register("MMM-DarkSkyForecast", {
     showCurrentConditions: true,
     showExtraCurrentConditions: true,
     showSummary: true,
-    forecasttableheadertext: '',
-    showforecasttablecolumnheadericons: true,
+    forecastTableHeaderText: '',
+    showForecastTableColumnHeaderIcons: true,
     showHourlyForecast: true,
     hourlyForecastInterval: 3,
     maxHourliesToShow: 3,
@@ -310,12 +310,12 @@ Module.register("MMM-DarkSkyForecast", {
       wrapper.appendChild(summaryWrapper);
     }
     
-    //forecasttableheadertext
-    if (this.config.forecasttableheadertext != "") {
-      var forecastheader = document.createElement("div");
-      forecastheader.className = "module-header";
-      forecastheader.innerHTML = this.config.forecasttableheadertext;
-      wrapper.appendChild(forecastheader);
+    //forecastTableHeaderText
+    if (this.config.forecastTableHeaderText != "") {
+      var forecastHeader = document.createElement("div");
+      forecastHeader.className = "module-header";
+      forecastHeader.innerHTML = this.config.forecastTableHeaderText;
+      wrapper.appendChild(forecastHeader);
     }
 
     var forecastWrapper;
@@ -323,7 +323,7 @@ Module.register("MMM-DarkSkyForecast", {
       forecastWrapper = document.createElement("div");
       forecastWrapper.className = "forecast-container";
 
-      if (this.config.forecastLayout == "table" && this.config.showforecasttablecolumnheadericons) {
+      if (this.config.forecastLayout == "table" && this.config.showForecastTableColumnHeaderIcons) {
         var headerRow = document.createElement("div");
         headerRow.className = "header-row";
 

--- a/MMM-DarkSkyForecast.js
+++ b/MMM-DarkSkyForecast.js
@@ -10,6 +10,8 @@ Module.register("MMM-DarkSkyForecast", {
     showCurrentConditions: true,
     showExtraCurrentConditions: true,
     showSummary: true,
+    forecasttableheadertext: '',
+    showforecasttablecolumnheadericons: true,
     showHourlyForecast: true,
     hourlyForecastInterval: 3,
     maxHourliesToShow: 3,
@@ -306,8 +308,14 @@ Module.register("MMM-DarkSkyForecast", {
       summaryWrapper.appendChild(summary);
 
       wrapper.appendChild(summaryWrapper);
-
-
+    }
+    
+    //forecasttableheadertext
+    if (this.config.forecasttableheadertext != "") {
+      var forecastheader = document.createElement("div");
+      forecastheader.className = "module-header";
+      forecastheader.innerHTML = this.config.forecasttableheadertext;
+      wrapper.appendChild(forecastheader);
     }
 
     var forecastWrapper;
@@ -315,7 +323,7 @@ Module.register("MMM-DarkSkyForecast", {
       forecastWrapper = document.createElement("div");
       forecastWrapper.className = "forecast-container";
 
-      if (this.config.forecastLayout == "table") {
+      if (this.config.forecastLayout == "table" && this.config.showforecasttablecolumnheadericons) {
         var headerRow = document.createElement("div");
         headerRow.className = "header-row";
 

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Find out your latitude and longitude here:
     </tr>
     <tr>
       <td><code>label_timeFormat</code></td>
-      <td>How you want the time formatted for hourly forecast display.  Accepts any valid moment.js format (https://momentjs.com/docs/#/displaying/format/).<br>The short 24h format kann be displayed by <code>"H[h]"</code> (e.g.: <code>14h</code>)<br><br><strong>Type</strong> <code>String</code><br>Defaults to <code>"h a"</code> (e.g.: <code>9 am</code>)</td>
+      <td>How you want the time formatted for hourly forecast display.  Accepts any valid moment.js format (https://momentjs.com/docs/#/displaying/format/).<br>The short 24h format kann be displayed by <code>"k[h]"</code> (e.g.: <code>14h</code>)<br><br><strong>Type</strong> <code>String</code><br>Defaults to <code>"h a"</code> (e.g.: <code>9 am</code>)</td>
     </tr>
     <tr>
       <td><code>label_days</code></td>

--- a/README.md
+++ b/README.md
@@ -82,6 +82,14 @@ Find out your latitude and longitude here:
       <td>Whether to show the forecast summary.<br><br><strong>Type</strong> <code>Boolean</code><br>Defaults to <code>true</code></td>
     </tr>
     <tr>
+      <td><code>forecastTableHeaderText</code></td>
+      <td>Show a header above the forecast table. Can be used instead of the regular header.<br><br><strong>Type</strong> <code>String</code><br>Defaults to <code>''</code></td>
+    </tr>
+    <tr>
+      <td><code>showForecastTableColumnHeaderIcons</code></td>
+      <td>Whether to show icons for the columns of the forecast table.<br><br><strong>Type</strong> <code>Boolean</code><br>Defaults to <code>true</code></td>
+    </tr>
+    <tr>
       <td><code>showHourlyForecast</code></td>
       <td>Whether to show hourly forecast information. when set to <code>true</code> it works with the <code>hourlyForecastInterval</code> and <code>maxHourliesToShow</code> parameters.<br><br><strong>Type</strong> <code>Boolean</code><br>Defaults to <code>true</code></td>
     </tr>

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Find out your latitude and longitude here:
     </tr>
     <tr>
       <td><code>forecastLayout</code></td>
-      <td>Can be set to <code>tiled</code> or <code>table</code>. How to display hourly and forecast information.  See below for screenshot examples of each.<br><br><strong>Type</strong> <code>String</code><br>Defaults to <code>true</code></td>
+      <td>Can be set to <code>tiled</code> or <code>table</code>. How to display hourly and forecast information.  See below for screenshot examples of each.<br><br><strong>Type</strong> <code>String</code><br>Defaults to <code>tiled</code></td>
     </tr>
     <tr>
       <td><code>label_maximum</code></td>

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Find out your latitude and longitude here:
     </tr>
     <tr>
       <td><code>label_timeFormat</code></td>
-      <td>How you want the time formatted for hourly forecast display.  Accepts any valid moment.js format (https://momentjs.com/docs/#/displaying/format/).<br><br><strong>Type</strong> <code>String</code><br>Defaults to <code>"h a"</code> (e.g.: <code>9 am</code>)</td>
+      <td>How you want the time formatted for hourly forecast display.  Accepts any valid moment.js format (https://momentjs.com/docs/#/displaying/format/).<br>The short 24h format kann be displayed by <code>"H[h]"</code> (e.g.: <code>14h</code>)<br><br><strong>Type</strong> <code>String</code><br>Defaults to <code>"h a"</code> (e.g.: <code>9 am</code>)</td>
     </tr>
     <tr>
       <td><code>label_days</code></td>


### PR DESCRIPTION
Optionally show a header above the forecast table (instead of the regular header).
Optionally hide the column header icons from the forecast table.
Added information how to format the timeFormat label for a short 24h format.
Corrected typos.